### PR TITLE
fix: :bug: Solución a error de mostrar nombres en grupos

### DIFF
--- a/resources/views/tools/chat-beta.blade.php
+++ b/resources/views/tools/chat-beta.blade.php
@@ -609,6 +609,14 @@
                                     $messageAttachments = collect($message->attachments ?? []);
                                     $isDeleted = $message->deleted_at !== null;
                                     $isEdited = $message->edited_at !== null && ! $isDeleted;
+                                    $showSenderName = $selectedConversationIsGroup
+                                        && ! $isDeleted
+                                        && ! $isSystem
+                                        && ! $isMine
+                                        && (
+                                            $loop->first
+                                            || $previousMessage?->sender_id !== $message->sender_id
+                                        );
                                 @endphp
                                 @if ($showDateSeparator)
                                     <div class="my-5 flex justify-center" data-chat-date-separator>
@@ -628,7 +636,7 @@
                                             </div>
                                         @else
                                             <div class="group relative min-w-[5rem] rounded-[1.1rem] px-3 py-2 shadow-sm transition {{ $isDeleted ? 'border border-dashed border-slate-300 bg-slate-100 text-slate-500' : ($isMine ? 'bg-[#d9fdd3] pb-4 pr-8 text-slate-800 hover:shadow-md' : 'border border-slate-200 bg-white text-brand-secondary') }} {{ (! $isDeleted && ! $isMine && (bool) ($message->mentions_auth_user ?? false)) ? 'ring-2 ring-sky-300 bg-sky-50/80 shadow-md' : '' }}">
-                                                @if ($selectedConversationIsGroup && ! $isDeleted && ! $isSystem)
+                                                @if ($showSenderName)
                                                     <p class="mb-1 truncate text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
                                                         {{ $message->sender?->name ?? 'Usuario' }}
                                                     </p>
@@ -1796,7 +1804,7 @@
                         && !isSystem
                         && !isMine
                         && !isDeleted
-                        && (index === 0 || previousDateKey !== currentDateKey || previousTimeLabel !== currentTimeLabel);
+                        && (index === 0 || Number(previousMessage?.sender_id || 0) !== Number(message.sender_id || 0));
                     const senderNameHtml = showSenderName
                         ? `<p class="mb-1 truncate text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">${escapeHtml(String(message.sender_name || 'Usuario'))}</p>`
                         : '';

--- a/tests/Feature/CompanyChatTest.php
+++ b/tests/Feature/CompanyChatTest.php
@@ -263,6 +263,60 @@ class CompanyChatTest extends TestCase
             ->assertSee('Emisor Grupo', false);
     }
 
+    public function test_group_messages_show_the_sender_name_again_when_someone_speaks_after_another_user(): void
+    {
+        Carbon::setTestNow(now()->setTime(12, 30, 0));
+
+        $senderOne = User::factory()->create(['name' => 'Antonio Morales']);
+        $senderTwo = User::factory()->create(['name' => 'Marta Gómez']);
+        $viewer = User::factory()->create(['name' => 'Lector Grupo']);
+
+        $this->acceptChatPolicy($senderOne);
+        $this->acceptChatPolicy($senderTwo);
+        $this->acceptChatPolicy($viewer);
+
+        $group = CompanyChatGroup::query()->create([
+            'name' => 'Grupo conversación',
+        ]);
+        $group->participants()->sync([$senderOne->id, $senderTwo->id, $viewer->id]);
+
+        $conversation = CompanyChatConversation::query()->create([
+            'company_chat_group_id' => $group->id,
+        ]);
+
+        $this->actingAs($senderOne)
+            ->post(route('chat.beta.messages.store', $conversation), [
+                'body' => 'Primero yo',
+            ])
+            ->assertRedirect(route('chat.beta', ['conversation' => $conversation->id]));
+
+        $this->actingAs($senderTwo)
+            ->post(route('chat.beta.messages.store', $conversation), [
+                'body' => 'Luego yo',
+            ])
+            ->assertRedirect(route('chat.beta', ['conversation' => $conversation->id]));
+
+        $this->actingAs($senderOne)
+            ->post(route('chat.beta.messages.store', $conversation), [
+                'body' => 'Vuelvo a hablar',
+            ])
+            ->assertRedirect(route('chat.beta', ['conversation' => $conversation->id]));
+
+        $response = $this->actingAs($viewer)->get(route('chat.beta', ['conversation' => $conversation->id]));
+
+        $response
+            ->assertOk()
+            ->assertSee('Antonio Morales', false)
+            ->assertSee('Marta Gómez', false);
+
+        $this->assertMatchesRegularExpression(
+            '/Antonio Morales.*?Primero yo.*?Marta Gómez.*?Luego yo.*?Antonio Morales.*?Vuelvo a hablar/s',
+            $response->getContent()
+        );
+
+        Carbon::setTestNow();
+    }
+
     public function test_group_mentions_are_stored_and_prioritised_for_the_mentioned_user(): void
     {
         $sender = User::factory()->create(['name' => 'Emisor Menciones']);


### PR DESCRIPTION
Cuando se mostraban los nombres en los grupos, como teníamos la lógica de que si un mensaje era mandado en el mismo minuto, no se mostrase el nombre de nuevo. El problema era que no estábamos contemplando si otro usuario de la conversación interrumpe hablando, aunque sea en ese mismo minuto.